### PR TITLE
Fix code mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ var obj = map.toObject();
 Dumps decoded structure into simple text output as you can see in the [demo](http://matej21.github.io/neon-js-dist/).
 
 ```javascript
-var text = neon.Dumper.toText(data)`;
+var text = neon.Dumper.toText(data);
 ```
 
 


### PR DESCRIPTION
There are no backticks after the right parentheses and before the semicolon in JavaScript syntax because running this code before fixing the mistake will result in a syntax error: unexpected end of input. So the cold should be `var text = neon.Dumper.toText(data);`, not ``var text = neon.Dumper.toText(data)`;``.